### PR TITLE
Remove unnecessary index-strategy setting

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -15,7 +15,6 @@ dev = [
 ]
 
 [tool.uv]
-index-strategy = "unsafe-best-match"
 exclude-newer = "7 days"
 
 [tool.uv.exclude-newer-package]


### PR DESCRIPTION
Remove `index-strategy = "unsafe-best-match"` from pyproject.toml.jinja as it is not necessary.