### PR TITLE
feat: auto-populate MISTRAL_API_KEY from current shell environment

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -9,7 +9,7 @@ project_name:
 mistral_api_key:
   type: str
   secret: true
-  default: ""
+  default: "{{ os.environ.get('MISTRAL_API_KEY', '') }}"
   help: "Mistral API key"
 
 collection_name:


### PR DESCRIPTION
Update copier.yml to use os.environ.get('MISTRAL_API_KEY', '') as the default value for mistral_api_key, so it automatically picks up the MISTRAL_API_KEY from the current shell if available.

This matches the behavior in workflows-starter-app.

Generated by Mistral Vibe.
Co-Authored-By: Mistral Vibe <vibe@mistral.ai>