### PR TITLE
Simplify Copier setup and auto-fill API key from shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ export MISTRAL_API_KEY=your-key   # optional
 
 Copier uses the **latest git tag** of the template (not uncommitted files). After changing the template, commit and tag a new release (e.g. `v1.0.2`) so `copier copy ./search-starter-app` picks up the changes.
 
-Initial setup only asks for **project name** and **collection name** (no port questions). Ports default to `18080` / `19072` in `.env`. If `MISTRAL_API_KEY` is exported in your shell, a post-copy task writes it into `.env` automatically (not prompted).
+Initial setup asks for **collection name**. The **destination folder** you pass on the command line is the project name (used in `pyproject.toml`, README title, Vespa container name, etc.) — e.g. `copier copy ./search-starter-app ./my-rag-app` creates `my-rag-app/` with `name = "my-rag-app"`. Ports default to `18080` / `19072` in `.env`. If `MISTRAL_API_KEY` is exported in your shell, a post-copy task writes it into `.env` automatically.
 
 ## Template Structure
 
@@ -83,7 +83,7 @@ Port selection is intentionally not part of the initial Copier questions. Genera
 
 | Variable           | Description                                      |
 | ------------------ | ------------------------------------------------ |
-| `project_name`     | Name of the project (pyproject.toml, container)  |
+| (destination path) | Project name = folder you pass to `copier copy`  |
 | `collection_name`  | Vespa collection / schema name                   |
 
 Generated `.env` sets default Vespa ports and `WORKSPACE_ROOT=.`; `MISTRAL_API_KEY` is filled from your shell when set, otherwise add it manually before ingest/search.

--- a/README.md
+++ b/README.md
@@ -34,9 +34,16 @@ From a local git checkout:
 copier copy ./search-starter-app my-search-project
 ```
 
-Copier uses the **latest git tag** of the template (not uncommitted files). After changing the template, commit and tag a new release (e.g. `v1.0.1`) so `copier copy ./search-starter-app` picks up the changes.
+Or use the setup wrapper (passes `MISTRAL_API_KEY` when exported):
 
-Initial setup only asks for **project name** and **collection name**. Ports default to `18080` / `19072` in `.env`; set `MISTRAL_API_KEY` in `.env` after copy (not prompted).
+```bash
+export MISTRAL_API_KEY=your-key   # optional
+./search-starter-app/scripts/setup my-search-project
+```
+
+Copier uses the **latest git tag** of the template (not uncommitted files). After changing the template, commit and tag a new release (e.g. `v1.0.2`) so `copier copy ./search-starter-app` picks up the changes.
+
+Initial setup only asks for **project name** and **collection name** (no port questions). Ports default to `18080` / `19072` in `.env`. If `MISTRAL_API_KEY` is exported in your shell, a post-copy task writes it into `.env` automatically (not prompted).
 
 ## Template Structure
 
@@ -79,4 +86,4 @@ Port selection is intentionally not part of the initial Copier questions. Genera
 | `project_name`     | Name of the project (pyproject.toml, container)  |
 | `collection_name`  | Vespa collection / schema name                   |
 
-Generated `.env` sets default Vespa ports and `WORKSPACE_ROOT=.`; add `MISTRAL_API_KEY` manually before ingest/search.
+Generated `.env` sets default Vespa ports and `WORKSPACE_ROOT=.`; `MISTRAL_API_KEY` is filled from your shell when set, otherwise add it manually before ingest/search.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ You also need [Docker](https://docs.docker.com/get-docker/) for local Vespa and 
 copier copy gh:mistralai/search-starter-app my-search-project
 ```
 
+From a local git checkout:
+
+```bash
+copier copy ./search-starter-app my-search-project
+```
+
+Copier uses the **latest git tag** of the template (not uncommitted files). After changing the template, commit and tag a new release (e.g. `v1.0.1`) so `copier copy ./search-starter-app` picks up the changes.
+
+Initial setup only asks for **project name** and **collection name**. Ports default to `18080` / `19072` in `.env`; set `MISTRAL_API_KEY` in `.env` after copy (not prompted).
+
 ## Template Structure
 
 ```
@@ -60,12 +70,13 @@ make search query="hello world"
 make bruno   # optional: API files under vespa/bruno/vespa/
 ```
 
+Port selection is intentionally not part of the initial Copier questions. Generated projects default to `18080` / `19072`; if needed later, users can edit `.env` (`VESPA_QUERY_PORT`, `VESPA_CONFIG_PORT`) without re-generating the project.
+
 ## Variables
 
 | Variable           | Description                                      |
 | ------------------ | ------------------------------------------------ |
 | `project_name`     | Name of the project (pyproject.toml, container)  |
-| `mistral_api_key`  | Mistral API key (written to `.env`, git-ignored) |
 | `collection_name`  | Vespa collection / schema name                   |
 
-Generated `.env` also sets `WORKSPACE_ROOT=.` so Bruno files are written inside the project.
+Generated `.env` sets default Vespa ports and `WORKSPACE_ROOT=.`; add `MISTRAL_API_KEY` manually before ingest/search.

--- a/copier.yml
+++ b/copier.yml
@@ -6,12 +6,6 @@ project_name:
   default: "my-search"
   help: "Project name"
 
-mistral_api_key:
-  type: str
-  secret: true
-  default: "{{ environ.get('MISTRAL_API_KEY', '') }}"
-  help: "Mistral API key"
-
 collection_name:
   type: str
   default: "exampledocs"

--- a/copier.yml
+++ b/copier.yml
@@ -1,10 +1,22 @@
 _min_copier_version: "9.0.0"
 _subdirectory: "template"
 
+_tasks:
+  - command:
+      - "{{ _copier_python }}"
+      - "{{ _copier_conf.src_path }}/scripts/populate_api_key.py"
+    when: "{{ _copier_operation == 'copy' }}"
+
 project_name:
   type: str
   default: "my-search"
   help: "Project name"
+
+mistral_api_key:
+  type: str
+  secret: true
+  default: ""
+  when: false
 
 collection_name:
   type: str

--- a/copier.yml
+++ b/copier.yml
@@ -7,11 +7,6 @@ _tasks:
       - "{{ _copier_conf.src_path }}/scripts/populate_api_key.py"
     when: "{{ _copier_operation == 'copy' }}"
 
-project_name:
-  type: str
-  default: "my-search"
-  help: "Project name"
-
 mistral_api_key:
   type: str
   secret: true

--- a/scripts/populate_api_key.py
+++ b/scripts/populate_api_key.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Write MISTRAL_API_KEY from the shell into the generated project's .env."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def main() -> None:
+    api_key = os.environ.get("MISTRAL_API_KEY", "")
+    if not api_key:
+        return
+
+    env_path = Path(".env")
+    if not env_path.exists():
+        return
+
+    lines: list[str] = []
+    for line in env_path.read_text().splitlines():
+        if line.startswith("MISTRAL_API_KEY="):
+            lines.append(f"MISTRAL_API_KEY={api_key}")
+        else:
+            lines.append(line)
+    env_path.write_text("\n".join(lines) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Convenience wrapper around `copier copy` (similar to workflows' setup CLI).
+set -euo pipefail
+
+TEMPLATE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEST="${1:?Usage: $0 <destination>}"
+shift || true
+
+ARGS=(copy "${TEMPLATE_DIR}" --trust "${DEST}")
+if [[ -n "${MISTRAL_API_KEY:-}" ]]; then
+  ARGS+=(--data "mistral_api_key=${MISTRAL_API_KEY}")
+fi
+
+exec copier "${ARGS[@]}" "$@"

--- a/template/.agents/skills/search/SKILL.md
+++ b/template/.agents/skills/search/SKILL.md
@@ -61,7 +61,7 @@ sample_data/                # Example documents
 
 ```bash
 uv sync
-# Set MISTRAL_API_KEY in .env (created by copier)
+# Set MISTRAL_API_KEY in .env (not prompted by copier)
 make setup-vespa          # start container + migrate schema
 make ingest path=sample_data/hello.txt
 make search query="hello world"

--- a/template/.agents/skills/search/SKILL.md
+++ b/template/.agents/skills/search/SKILL.md
@@ -61,7 +61,7 @@ sample_data/                # Example documents
 
 ```bash
 uv sync
-# Set MISTRAL_API_KEY in .env (not prompted by copier)
+# Export MISTRAL_API_KEY before copier copy to auto-fill .env (not prompted)
 make setup-vespa          # start container + migrate schema
 make ingest path=sample_data/hello.txt
 make search query="hello world"

--- a/template/.agents/skills/search/reference.md
+++ b/template/.agents/skills/search/reference.md
@@ -106,7 +106,7 @@ Returns chunk count (int). Pass `context=IngestContext()` for custom ingest scop
 
 | Variable | Default | Role |
 |----------|---------|------|
-| `MISTRAL_API_KEY` | (empty) | API key; set in `.env` at project generation |
+| `MISTRAL_API_KEY` | (empty) | API key; set manually in `.env` after `copier copy` |
 | `MISTRAL_API_URL` | `https://api.mistral.ai` | Optional custom API base URL |
 
 ### Vespa (search-starter-app `.env`)

--- a/template/.agents/skills/search/reference.md
+++ b/template/.agents/skills/search/reference.md
@@ -106,7 +106,7 @@ Returns chunk count (int). Pass `context=IngestContext()` for custom ingest scop
 
 | Variable | Default | Role |
 |----------|---------|------|
-| `MISTRAL_API_KEY` | (empty) | API key; set manually in `.env` after `copier copy` |
+| `MISTRAL_API_KEY` | from shell or empty | Auto-filled in `.env` when exported before `copier copy` |
 | `MISTRAL_API_URL` | `https://api.mistral.ai` | Optional custom API base URL |
 
 ### Vespa (search-starter-app `.env`)

--- a/template/.env.jinja
+++ b/template/.env.jinja
@@ -1,6 +1,8 @@
-MISTRAL_API_KEY={{ mistral_api_key }}
+# Set your Mistral API key here (not asked during `copier copy`)
+MISTRAL_API_KEY=
 MISTRAL_API_URL=https://api.mistral.ai
-VESPA_QUERY_PORT=18080
-VESPA_CONFIG_PORT=19072
 COLLECTION_NAME={{ collection_name }}
 WORKSPACE_ROOT=.
+# Optional: change only if ports 18080 / 19072 are already in use
+VESPA_QUERY_PORT=18080
+VESPA_CONFIG_PORT=19072

--- a/template/.env.jinja
+++ b/template/.env.jinja
@@ -1,5 +1,4 @@
-# Set your Mistral API key here (not asked during `copier copy`)
-MISTRAL_API_KEY=
+MISTRAL_API_KEY={{ mistral_api_key }}
 MISTRAL_API_URL=https://api.mistral.ai
 COLLECTION_NAME={{ collection_name }}
 WORKSPACE_ROOT=.

--- a/template/Makefile.jinja
+++ b/template/Makefile.jinja
@@ -5,7 +5,7 @@ include .env
 export
 endif
 
-VESPA_CONTAINER := {{ project_name }}-vespa
+VESPA_CONTAINER := {{ _copier_conf.dst_path.name }}-vespa
 VESPA_QUERY_PORT := $(or $(VESPA_QUERY_PORT),18080)
 VESPA_CONFIG_PORT := $(or $(VESPA_CONFIG_PORT),19072)
 VESPA_ENDPOINT := $(or $(VESPA_ENDPOINT),http://localhost:$(VESPA_QUERY_PORT))

--- a/template/Makefile.jinja
+++ b/template/Makefile.jinja
@@ -1,5 +1,10 @@
 .PHONY: installdeps setup-vespa start-vespa stop-vespa reset-vespa migrate-vespa verify-vespa ingest search bruno generate-vespa-lock
 
+ifneq (,$(wildcard .env))
+include .env
+export
+endif
+
 VESPA_CONTAINER := {{ project_name }}-vespa
 VESPA_QUERY_PORT := $(or $(VESPA_QUERY_PORT),18080)
 VESPA_CONFIG_PORT := $(or $(VESPA_CONFIG_PORT),19072)
@@ -27,12 +32,10 @@ verify-vespa:
 stop-vespa:
 	docker compose stop vespa
 
-## Stop Vespa and remove the data volume (wipes indexed documents; run `make setup-vespa` to start fresh)
+## Stop Vespa and remove this project's data volume (wipes indexed documents; run `make setup-vespa` to start fresh)
 reset-vespa:
-	docker compose stop vespa
-	docker compose rm -f vespa
-	-docker volume rm $$(docker volume ls -qf 'name=vespa-data')
-	@echo "Vespa container and data volume removed. Run: make setup-vespa"
+	docker compose down -v --remove-orphans
+	@echo "Vespa stopped and project volume removed. Run: make setup-vespa"
 
 migrate-vespa: verify-vespa
 	uv run mistral-vespa migrate --app-dir src/vespa_app \

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -10,7 +10,7 @@ SDK namespace: `mistralai.search.toolkit` — see the [toolkit docs](https://git
 make installdeps
 ```
 
-Set `MISTRAL_API_KEY` in `.env` (empty after `copier copy` — not prompted during setup).
+Set `MISTRAL_API_KEY` in `.env` if needed (auto-filled from your shell when exported; not prompted during `copier copy`).
 
 ## Commands
 

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -1,4 +1,4 @@
-# {{ project_name }}
+# {{ _copier_conf.dst_path.name }}
 
 A [Mistral Search Toolkit](https://pypi.org/project/mistralai-search-toolkit/) project with a Vespa backend.
 
@@ -10,7 +10,7 @@ SDK namespace: `mistralai.search.toolkit` — see the [toolkit docs](https://git
 make installdeps
 ```
 
-Set `MISTRAL_API_KEY` in `.env` if needed (auto-filled from your shell when exported; not prompted during `copier copy`).
+Set `MISTRAL_API_KEY` in `.env` if needed (auto-filled from your shell when exported; not prompted during `copier copy`). Project name matches the folder you chose when running `copier copy` (this directory).
 
 ## Commands
 

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -10,7 +10,7 @@ SDK namespace: `mistralai.search.toolkit` — see the [toolkit docs](https://git
 make installdeps
 ```
 
-Set `MISTRAL_API_KEY` in `.env` (created by copier). Vespa endpoints and `COLLECTION_NAME` are pre-configured.
+Set `MISTRAL_API_KEY` in `.env` (empty after `copier copy` — not prompted during setup).
 
 ## Commands
 
@@ -22,7 +22,7 @@ make setup-vespa
 
 Expected output (success): Vespa container `Healthy`, migration `"activated": true`, then `Application is up!` / `Application ready`. Warnings about `no_query_match` and `summary_fields` are normal. First startup may take up to a minute.
 
-If ports **18080** / **19072** are already in use, set `VESPA_QUERY_PORT` / `VESPA_CONFIG_PORT` in `.env` and align `docker-compose.yaml` host mappings.
+You are not asked for ports during `copier copy`; defaults are set for you. If ports **18080** / **19072** are already in use, update `VESPA_QUERY_PORT` / `VESPA_CONFIG_PORT` in `.env` and rerun `make setup-vespa`.
 
 To wipe local Vespa data and redeploy from scratch:
 

--- a/template/docker-compose.yaml.jinja
+++ b/template/docker-compose.yaml.jinja
@@ -1,6 +1,6 @@
 # Local Vespa for development.
-# Query API: http://localhost:18080  (host 18080 → container :8080)
-# Config server: http://localhost:19072  (host 19072 → container :19071)
+# Query API: http://localhost:${VESPA_QUERY_PORT:-18080}  (.env VESPA_QUERY_PORT)
+# Config server: http://localhost:${VESPA_CONFIG_PORT:-19072}  (.env VESPA_CONFIG_PORT)
 
 services:
   vespa:
@@ -8,8 +8,8 @@ services:
     container_name: {{ project_name }}-vespa
     hostname: {{ project_name }}-vespa
     ports:
-      - "18080:8080"
-      - "19072:19071"
+      - "${VESPA_QUERY_PORT:-18080}:8080"
+      - "${VESPA_CONFIG_PORT:-19072}:19071"
     volumes:
       - vespa-data:/opt/vespa/var
     environment:

--- a/template/docker-compose.yaml.jinja
+++ b/template/docker-compose.yaml.jinja
@@ -5,16 +5,16 @@
 services:
   vespa:
     image: vespaengine/vespa:latest
-    container_name: {{ project_name }}-vespa
-    hostname: {{ project_name }}-vespa
+    container_name: {{ _copier_conf.dst_path.name }}-vespa
+    hostname: {{ _copier_conf.dst_path.name }}-vespa
     ports:
       - "${VESPA_QUERY_PORT:-18080}:8080"
       - "${VESPA_CONFIG_PORT:-19072}:19071"
     volumes:
       - vespa-data:/opt/vespa/var
     environment:
-      - VESPA_CONFIGSERVERS={{ project_name }}-vespa
-      - VESPA_HOSTNAME={{ project_name }}-vespa
+      - VESPA_CONFIGSERVERS={{ _copier_conf.dst_path.name }}-vespa
+      - VESPA_HOSTNAME={{ _copier_conf.dst_path.name }}-vespa
     deploy:
       resources:
         limits:

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -1,5 +1,5 @@
 [project]
-name = "{{ project_name }}"
+name = "{{ _copier_conf.dst_path.name }}"
 version = "0.1.0"
 description = "A Mistral Search Toolkit project"
 requires-python = ">=3.12,<3.15"

--- a/template/src/vespa_app/migrations/001_create_index_schema.py.jinja
+++ b/template/src/vespa_app/migrations/001_create_index_schema.py.jinja
@@ -1,4 +1,4 @@
-"""Initial Vespa schema for {{ project_name }}.
+"""Initial Vespa schema for {{ _copier_conf.dst_path.name }}.
 
 Defines the ``{{ collection_name }}`` index schema. ``COLLECTION_NAME`` in
 ``.env`` must match this migration.


### PR DESCRIPTION
## Summary

- Remove Vespa port and API key prompts from initial `copier copy` (defaults live in `.env` / `docker-compose`).
- Auto-fill `MISTRAL_API_KEY` in generated `.env` when exported in the shell (post-copy task + optional `scripts/setup` wrapper).
- Improve Makefile (`include .env`, scoped `reset-vespa`) and document Copier usage in README.

## Test plan

- [ ] `export MISTRAL_API_KEY=... && copier copy ./search-starter-app --trust /tmp/test` → template **v1.0.2+**, task runs, `.env` contains key
- [ ] `copier copy ./search-starter-app --trust /tmp/test` → only project name + collection name (no port/API prompts)
- [ ] `make integration-test` in template repo passes
- [ ] Tag `v1.0.2` on merge if releasing template versions by tag


Made with [Cursor](https://cursor.com)