### PR TITLE
fix(template): make the tuned hybrid query profile actually rank

### DIFF
--- a/template/Makefile.jinja
+++ b/template/Makefile.jinja
@@ -49,9 +49,9 @@ ingest:
 	uv run python -m entrypoints.ingest $(path)
 
 ## Search the indexed collection (Search Toolkit QueryEngine)
-## Usage: make search query="hello world" [top_k=5]
+## Usage: make search query="hello world" [top_k=5] [query_profile=hybrid-search]
 search:
-	uv run python -m entrypoints.search "$(query)" $(if $(top_k),--top-k $(top_k),)
+	uv run python -m entrypoints.search "$(query)" $(if $(top_k),--top-k $(top_k),) $(if $(query_profile),--query-profile $(query_profile),)
 
 ## Generate Bruno API files under vespa/bruno/vespa/ (requires WORKSPACE_ROOT in .env)
 bruno:

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -48,6 +48,20 @@ Uses `QueryEngine` with `VectorRetriever` (hybrid BM25 + vector via Vespa):
 make search query="hello world"
 ```
 
+#### Custom query profile
+
+Ranking weights live in a Vespa **query profile**, not in the request. The search defaults to the `hybrid-search` profile (tuned BM25 + vector weights, defined in `src/vespa_app/migrations/001_create_index_schema.py`). Pass `query_profile=` to use another one:
+
+```bash
+make search query="hello world" query_profile=hybrid-profile
+```
+
+To add your own, register it with `add_query_profiles([...])` in a new `00X_*.py` migration, rerun `make migrate-vespa`, then select it by name:
+
+```bash
+make search query="hello world" query_profile=my-profile
+```
+
 ### Bruno API files (optional)
 
 ```bash

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -50,13 +50,9 @@ make search query="hello world"
 
 #### Custom query profile
 
-Ranking weights live in a Vespa **query profile**, not in the request. The search defaults to the `hybrid-search` profile (tuned BM25 + vector weights, defined in `src/vespa_app/migrations/001_create_index_schema.py`). Pass `query_profile=` to use another one:
+Ranking weights live in a Vespa **query profile**, not in the request. The search defaults to the `hybrid-search` profile (tuned BM25 + vector weights, defined in `src/vespa_app/migrations/001_create_index_schema.py`).
 
-```bash
-make search query="hello world" query_profile=hybrid-profile
-```
-
-To add your own, register it with `add_query_profiles([...])` in a new `00X_*.py` migration, rerun `make migrate-vespa`, then select it by name:
+To use your own, register it with `add_query_profiles([...])` in a new `00X_*.py` migration, rerun `make migrate-vespa`, then select it by name with `query_profile=`:
 
 ```bash
 make search query="hello world" query_profile=my-profile

--- a/template/src/entrypoints/search.py
+++ b/template/src/entrypoints/search.py
@@ -1,7 +1,7 @@
 """Search an indexed Vespa collection.
 
 Usage:
-    python -m entrypoints.search <query> [--top-k 5]
+    python -m entrypoints.search <query> [--top-k 5] [--query-profile hybrid-search]
 """
 
 import argparse
@@ -24,6 +24,11 @@ async def main() -> None:
     parser.add_argument(
         "--top-k", type=int, default=5, help="Number of results (default: 5)"
     )
+    parser.add_argument(
+        "--query-profile",
+        default="hybrid-search",
+        help="Vespa query profile to rank with (default: hybrid-search)",
+    )
     args = parser.parse_args()
 
     api_key = os.environ.get("MISTRAL_API_KEY", "")
@@ -39,6 +44,7 @@ async def main() -> None:
     vector_store = app.get_search_index(
         VespaClientConfig(endpoint=vespa_endpoint()),
         collection_name=collection_name,
+        query_profile=args.query_profile,
     )
     embedder = MistralEmbedder(client=mistral_client)
     query_engine = QueryEngine(
@@ -48,6 +54,7 @@ async def main() -> None:
     print(f"Query: {args.query!r}")
     print(f"Collection: {collection_name}")
     print(f"Top-K: {args.top_k}")
+    print(f"Query profile: {args.query_profile}")
 
     result = await query_engine.search(
         query=args.query,

--- a/template/src/vespa_app/migrations/001_create_index_schema.py.jinja
+++ b/template/src/vespa_app/migrations/001_create_index_schema.py.jinja
@@ -48,7 +48,7 @@ class CreateIndexSchemaMigration(VespaMigration):
                 QueryProfile(
                     name="hybrid-search",
                     fields=[
-                        QueryField(name="ranking.profile", value="root"),
+                        QueryField(name="ranking.profile", value="weighted-rank2"),
                         QueryField(name="hits", value=10),
                         QueryField(
                             name="ranking.features.query(bm25_chunks_max_weight)",
@@ -58,7 +58,6 @@ class CreateIndexSchemaMigration(VespaMigration):
                             name="ranking.features.query(bm25_chunks_avg_weight)",
                             value=0.3,
                         ),
-                        QueryField(name="ranking.features.query(bm25_title_weight)", value=0.5),
                         QueryField(
                             name="ranking.features.query(match_chunks_weight)",
                             value=0.5,

--- a/template/src/vespa_app/migrations/001_create_index_schema.py.jinja
+++ b/template/src/vespa_app/migrations/001_create_index_schema.py.jinja
@@ -39,6 +39,8 @@ class CreateIndexSchemaMigration(VespaMigration):
             mode=SearchMode.INDEX,
             embedding_dimensions=128,
             schema_version=1,
+            # Auto-generated default profile; ships with all ranking weights at 0.
+            # The search entrypoint defaults to the tuned "hybrid-search" profile below.
             default_query_profile_name="hybrid-profile",
             id_field="document_filename",
         )

--- a/template/src/vespa_app/migrations/001_create_index_schema.py.jinja
+++ b/template/src/vespa_app/migrations/001_create_index_schema.py.jinja
@@ -60,6 +60,7 @@ class CreateIndexSchemaMigration(VespaMigration):
                             name="ranking.features.query(bm25_chunks_avg_weight)",
                             value=0.3,
                         ),
+                        QueryField(name="ranking.features.query(bm25_title_weight)", value=0.5),
                         QueryField(
                             name="ranking.features.query(match_chunks_weight)",
                             value=0.5,


### PR DESCRIPTION
## Problem

The starter's `hybrid-search` query profile was defined with carefully tuned BM25 + vector weights, but those weights never actually affected ranking:

1. **`ranking.profile` was set to `root`.** In the generated `.sd`, `root` declares all the ranking *functions* but has **no `first-phase`/`second-phase` expression** — it's only a base profile to inherit from. Selecting it makes Vespa fall back to default `nativeRank`, so the `query(*_weight)` values had no formula to plug into.

2. **The default search path never used `hybrid-search` anyway.** `search.py` called `get_search_index(...)` with no profile, which resolves to `default_query_profile_name` = `hybrid-profile` — the toolkit's auto-generated profile, whose weights all default to `0`. So even after fixing (1), the tuned profile was dead code.

Weights can only be supplied via a query profile (the high-level `VectorSearchQuery` API has no per-query weight field), and the auto-generated default profile can't carry tuned weights (it's generated with `0` defaults, and the duplicate-name guard blocks overriding it with a same-named custom profile). So the tuned profile has to be selected explicitly at the entrypoint.

## Changes

**Ranking fix** (`migrations/001_create_index_schema.py.jinja`):
- `ranking.profile`: `root` → **`weighted-rank2`** (the profile that actually consumes these weights: `bm25_chunks_max/avg` in first-phase; `match_chunks` + `chunks_embeddings_avg_cosine_similarity` in second-phase).
- Comment at `default_query_profile_name` noting the auto profile ships with zero weights.

**Wire it up** so the tuned profile is actually used:
- `search.py`: new `--query-profile` arg (**default `hybrid-search`**), passed to `get_search_index(...)` and printed in the run header.
- `Makefile`: optional `query_profile=` passthrough (`make search query="..." query_profile=hybrid-profile`).
- `README`: document the default profile and how to add/select a custom one.

Notes:
- `bm25_title_weight` is kept as an intentional placeholder. It's currently a no-op (the v1 schema has no bm25-enabled `title` field, so no `bm25_title` rank feature), but harmless.
- `chunks_embeddings_avg_distance_weight` is left at its `0` default — cosine similarity is the chosen semantic signal.

## Verification

Rendered the committed template with copier (`collection_name=exampledocs`) and ran the full README workflow against a fresh, isolated Vespa (alternate ports + container):

- `installdeps`, `setup-vespa` (migration `"activated": true`, `Application ready`), `ingest` (text + PDF/OCR, 62 chunks), `search` — all green.
- Default search reports `Query profile: hybrid-search`; `query_profile=hybrid-profile` override works.
- Resolved `hybrid-search` via `migrate_to_package`: `ranking.profile = weighted-rank2` with the tuned weights present.

Note: on the 2-document sample corpus, `hybrid-search` and `hybrid-profile` return identical output — the displayed score is the client-side `best_chunks` value and all matches are returned regardless of document ranking. The weight difference only manifests on a corpus large enough that phase ranking decides which docs reach the returned set.

> The migration file's "do not edit once deployed" header refers to *generated* projects; this changes only the template source, so existing deployments are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)