### PR TITLE
Pin search-toolkit to 0.0.8

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A Mistral Search Toolkit project"
 requires-python = ">=3.12,<3.15"
 dependencies = [
-    "mistralai-search-toolkit[text-splitter-langchain,vespa]",
+    "mistralai-search-toolkit[text-splitter-langchain,vespa]==0.0.8",
     "python-dotenv>=0.9.9",
 ]
 


### PR DESCRIPTION
## Summary

- Pin `mistralai-search-toolkit` to `==0.0.8` in the template `pyproject.toml`
- The upcoming `0.0.9` release introduces breaking changes — pinning lets us control when to upgrade the starter app and adapt to those changes on our own schedule

## Test plan

- [ ] Verify `copier copy` still generates a working project with the pinned version
- [ ] Confirm `uv sync` resolves dependencies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)