### PR TITLE
Upgrade to search-toolkit 0.0.9

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A Mistral Search Toolkit project"
 requires-python = ">=3.12,<3.15"
 dependencies = [
-    "mistralai-search-toolkit[text-splitter-langchain,vespa]==0.0.8",
+    "mistralai-search-toolkit[text-splitter-langchain,vespa]==0.0.9",
     "python-dotenv>=0.9.9",
 ]
 

--- a/template/src/vespa_app/migrations/001_create_index_schema.py.jinja
+++ b/template/src/vespa_app/migrations/001_create_index_schema.py.jinja
@@ -11,14 +11,14 @@ import os
 
 from vespa.package import QueryField
 
-from mistralai.search.toolkit.plugins.vespa.app.schemas.app import SearchMode
+from mistralai.search.toolkit.plugins.vespa.app.schemas.app import IndexingMode, SearchMode
 from mistralai.search.toolkit.plugins.vespa.app.schemas.query_profile import (
     QueryProfile,
 )
 from mistralai.search.toolkit.plugins.vespa.migration import (
     VespaMigration,
     add_query_profiles,
-    create_default_schema,
+    create_schema,
     set_app_name,
 )
 from mistralai.search.toolkit.plugins.vespa.search.ranking_profile import RankingProfile
@@ -34,15 +34,14 @@ class CreateIndexSchemaMigration(VespaMigration):
 
     def migrate(self) -> None:
         set_app_name(_COLLECTION)
-        create_default_schema(
+        create_schema(
             name=_COLLECTION,
             mode=SearchMode.INDEX,
             embedding_dimensions=128,
-            schema_version=1,
+            indexing_mode=IndexingMode.DOCUMENT_PER_CHUNK,
             # Auto-generated default profile; ships with all ranking weights at 0.
             # The search entrypoint defaults to the tuned "hybrid-search" profile below.
             default_query_profile_name="hybrid-profile",
-            id_field="document_filename",
         )
 
         add_query_profiles(


### PR DESCRIPTION
## Summary

- Pin `mistralai-search-toolkit` to `==0.0.9`
- Migrate schema creation from `create_default_schema` to `create_schema` with `IndexingMode.DOCUMENT_PER_CHUNK`
- Drop deprecated `id_field` and `schema_version` params

The 0.0.9 release introduces breaking changes (new document model, `indexing_mode` required on schemas, `create_default_schema` removed). The ingestion and search entrypoints are unaffected — their public API surface hasn't changed.

## Test plan

- [ ] `copier copy` generates a working project
- [ ] `make deploy` succeeds with the new schema
- [ ] `make ingest` and `make search` work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)