### PR TITLE
Upgrade to search-toolkit 0.0.10

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A Mistral Search Toolkit project"
 requires-python = ">=3.12,<3.15"
 dependencies = [
-    "mistralai-search-toolkit[text-splitter-langchain,vespa]==0.0.9",
+    "mistralai-search-toolkit[text-splitter-langchain,vespa]==0.0.10",
     "python-dotenv>=0.9.9",
 ]
 

--- a/template/src/vespa_app/migrations/001_create_index_schema.py.jinja
+++ b/template/src/vespa_app/migrations/001_create_index_schema.py.jinja
@@ -25,7 +25,7 @@ from mistralai.search.toolkit.plugins.vespa.search.ranking_profile import Rankin
 
 _COLLECTION = os.environ.get("COLLECTION_NAME", "{{ collection_name }}")
 _YQL_HYBRID = RankingProfile(_COLLECTION).get_yql_select_hybrid(
-    embedding_field_names=["chunks_embeddings"],
+    embedding_field_names=["content_embedding"],
 )
 
 
@@ -52,20 +52,15 @@ class CreateIndexSchemaMigration(VespaMigration):
                         QueryField(name="ranking.profile", value="weighted-rank2"),
                         QueryField(name="hits", value=10),
                         QueryField(
-                            name="ranking.features.query(bm25_chunks_max_weight)",
+                            name="ranking.features.query(bm25_content_weight)",
                             value=0.5,
                         ),
                         QueryField(
-                            name="ranking.features.query(bm25_chunks_avg_weight)",
-                            value=0.3,
-                        ),
-                        QueryField(name="ranking.features.query(bm25_title_weight)", value=0.5),
-                        QueryField(
-                            name="ranking.features.query(match_chunks_weight)",
+                            name="ranking.features.query(match_content_weight)",
                             value=0.5,
                         ),
                         QueryField(
-                            name="ranking.features.query(chunks_embeddings_avg_cosine_similarity_weight)",
+                            name="ranking.features.query(content_embedding_cosine_similarity_score_weight)",
                             value=5.0,
                         ),
                         QueryField(name="yql", value=_YQL_HYBRID),


### PR DESCRIPTION
## Summary
- Bump `search-toolkit` dependency to 0.0.10 in the template `pyproject.toml`.
- Update the initial index-schema migration to use the content-based ranking feature names (matching DOCUMENT_PER_CHUNK indexing):
  - embedding field `chunks_embeddings` → `content_embedding`
  - `bm25_chunks_max_weight` → `bm25_content_weight`
  - `match_chunks_weight` → `match_content_weight`
  - `chunks_embeddings_avg_cosine_similarity_weight` → `content_embedding_cosine_similarity_score_weight`
  - dropped the now-unused `bm25_chunks_avg_weight` and `bm25_title_weight` weights

## Notes
These ranking feature names are string identifiers that fail silently if they don't match the schema the toolkit generates (a wrong name means the weight is ignored, not an error). Worth confirming they match search-toolkit 0.0.10's generated schema before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)