### PR TITLE
docs(mcp): sharpen open vs read tool wording

### DIFF
--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -107,10 +107,10 @@ The server fails fast at startup with a clear error if `MISTRAL_API_KEY` is miss
 |------|-------------|
 | `search(query, top_k=5)` | {% if backend == 'vespa' %}Hybrid BM25 + vector search{% else %}Dense vector search{% endif %}; returns ranked chunks with score, content, source_id, locator, **start_offset**, **end_offset**, and metadata |
 | `ingest(uri)` | Ingest a local path/directory, `file://` URI, or `http(s)://` URL; text files use plain-text extraction, everything else uses Mistral OCR |
-| `open_source(source_id, start_offset, end_offset, window=2)` | Expand around a search hit — returns the anchor chunk plus `window` neighbours on each side, in reading order |
-| `navigate_source(source_id, start_offset, end_offset, direction, top_k=1)` | Step through a document from a known position; `direction` is `"next"` or `"previous"` |
-| `read_source(source_id, start_offset=None, end_offset=None, top_k=20)` | Fetch a known offset range directly; omit either bound to read from the start or to the end |
-| `grep_source(source_id, pattern, mode="phrase", top_k=5)` | Lexical search within a single source; `mode` is `"phrase"` (ordered) or `"term"` (any order) |
+| `open(source_id, start_offset, end_offset, window=2)` | Expand context around a chunk from search — returns the anchor chunk plus `window` neighbours on each side, in reading order; `window` controls the radius |
+| `navigate(source_id, start_offset, end_offset, direction, top_k=1)` | Step through a document from a known position; `direction` is `"next"` or `"previous"` |
+| `read(source_id, start_offset=None, end_offset=None, top_k=20)` | Fetch a known offset range directly, no context expansion; omit either bound to read from the start or to the end |
+| `grep(source_id, pattern, mode="phrase", top_k=5)` | Lexical search within a single source; `mode` is `"phrase"` (ordered) or `"term"` (any order) |
 
 ### Vibe CLI
 

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -105,9 +105,9 @@ The server fails fast at startup with a clear error if `MISTRAL_API_KEY` is miss
 
 | Tool | Description |
 |------|-------------|
-| `search(query, top_k=5)` | {% if backend == 'vespa' %}Hybrid BM25 + vector search{% else %}Dense vector search{% endif %}; returns ranked chunks with score, content, source_id, locator, **start_offset**, **end_offset**, and metadata |
+| `search(query, top_k=5)` | {% if backend == 'vespa' %}Hybrid BM25 + vector search{% else %}Dense vector search{% endif %}; returns ranked chunks with **id**, score, content, source_id, locator, **start_offset**, **end_offset**, and metadata |
 | `ingest(uri)` | Ingest a local path/directory, `file://` URI, or `http(s)://` URL; text files use plain-text extraction, everything else uses Mistral OCR |
-| `open(source_id, start_offset, end_offset, window=2)` | Expand context around a chunk from search — returns the anchor chunk plus `window` neighbours on each side, in reading order; `window` controls the radius |
+| `open(chunk_id, window=2)` | Expand context around a chunk from search — pass the chunk `id`, the server resolves its position and returns the anchor chunk plus `window` neighbours on each side, in reading order; `window` controls the radius |
 | `navigate(source_id, start_offset, end_offset, direction, top_k=1)` | Step through a document from a known position; `direction` is `"next"` or `"previous"` |
 | `read(source_id, start_offset=None, end_offset=None, top_k=20)` | Fetch a known offset range directly, no context expansion; omit either bound to read from the start or to the end |
 | `grep(source_id, pattern, mode="phrase", top_k=5)` | Lexical search within a single source; `mode` is `"phrase"` (ordered) or `"term"` (any order) |

--- a/template/src/entrypoints/mcp_server.py
+++ b/template/src/entrypoints/mcp_server.py
@@ -8,6 +8,7 @@ from urllib.request import url2pathname
 import httpx
 from dotenv import load_dotenv
 from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
 from mistralai.client import Mistral
 from mistralai.search.toolkit.embedders import MistralEmbedder
 from mistralai.search.toolkit.document import compute_id
@@ -87,7 +88,7 @@ mcp = FastMCP(
         "Retrieval loop: start with `search` to find relevant chunks across the "
         "collection, then drill into a promising hit *within its document* without "
         "re-running a global search:\n"
-        "- `open`     — expand context around a chunk (`window` controls the radius)\n"
+        "- `open`     — expand context around a chunk by its `id` (`window` controls the radius)\n"
         "- `grep`     — jump to an exact term or phrase in the same document\n"
         "- `navigate` — step sequentially through adjacent chunks\n"
         "- `read`     — fetch a known offset range directly (no context expansion)\n"
@@ -102,11 +103,13 @@ mcp = FastMCP(
 def _format_chunks(results: list) -> list[dict]:
     """Serialise SearchResult objects into a consistent dict shape.
 
-    Includes start_offset / end_offset so the model can pass them directly
-    to the agentic navigation tools (open, navigate, …).
+    Includes the chunk `id` (pass to open()) and start_offset / end_offset
+    (pass to navigate() / read()) so the model can drive the agentic
+    navigation tools directly.
     """
     return [
         {
+            "id": hit.chunk.id,
             "score": hit.score,
             "content": hit.chunk.content,
             "source_id": hit.chunk.source_id,
@@ -245,29 +248,31 @@ async def delete(source_id: str) -> str:
 # ---------------------------------------------------------------------------
 
 @mcp.tool()
-async def open(
-    source_id: str, start_offset: int, end_offset: int, window: int = 2
-) -> list[dict]:
+async def open(chunk_id: str, window: int = 2) -> list[dict]:
     """Expand context around a chunk from search: return it plus adjacent chunks in reading order.
 
-    Use when you have a chunk from search() and want to see a window around it;
-    `window` controls how many chunks are pulled in on each side. When you already
-    know the exact range and want those chunks verbatim, use read() instead.
+    Pass the `id` of a chunk from a search() result; the server resolves its
+    position and pulls in `window` neighbouring chunks on each side. When you
+    already know the exact offset range and want those chunks verbatim, use
+    read() instead.
 
     Args:
-        source_id:    Source identifier from a search() result.
-        start_offset: start_offset from the anchor search() result.
-        end_offset:   end_offset from the anchor search() result.
-        window:       Number of adjacent chunks to fetch in each direction (default 2).
+        chunk_id: `id` of a chunk from a search() result.
+        window:   Number of adjacent chunks to fetch in each direction (default 2).
     """
+    anchor = await _navigable_store.get_chunk(chunk_id)
+    if anchor is None:
+        raise ToolError(f"chunk not found: {chunk_id!r}")
+    source_id = anchor.chunk.source_id
+    start_offset = anchor.chunk.start_offset or 0
+    end_offset = anchor.chunk.end_offset or 0
     prev = await _navigable_store.navigate(
         source_id, start_offset, end_offset, NavigationDirection.PREVIOUS, top_k=window
     )
-    current = await _navigable_store.read(source_id, start_offset, end_offset)
     nxt = await _navigable_store.navigate(
         source_id, start_offset, end_offset, NavigationDirection.NEXT, top_k=window
     )
-    return _format_chunks(prev + current + nxt)
+    return _format_chunks(prev + [anchor] + nxt)
 
 
 @mcp.tool()

--- a/template/src/entrypoints/mcp_server.py
+++ b/template/src/entrypoints/mcp_server.py
@@ -87,10 +87,10 @@ mcp = FastMCP(
         "Retrieval loop: start with `search` to find relevant chunks across the "
         "collection, then drill into a promising hit *within its document* without "
         "re-running a global search:\n"
-        "- `open`     — expand context around a chunk\n"
+        "- `open`     — expand context around a chunk (`window` controls the radius)\n"
         "- `grep`     — jump to an exact term or phrase in the same document\n"
         "- `navigate` — step sequentially through adjacent chunks\n"
-        "- `read`     — read a known character-offset range\n"
+        "- `read`     — fetch a known offset range directly (no context expansion)\n"
         "Then call `search` again with a query informed by what you have read to "
         "connect information across documents. To scope a search to one document, "
         "include its title or source_id in the query.\n\n"
@@ -248,7 +248,11 @@ async def delete(source_id: str) -> str:
 async def open(
     source_id: str, start_offset: int, end_offset: int, window: int = 2
 ) -> list[dict]:
-    """Expand context around a retrieved chunk, returning adjacent chunks in reading order.
+    """Expand context around a chunk from search: return it plus adjacent chunks in reading order.
+
+    Use when you have a chunk from search() and want to see a window around it;
+    `window` controls how many chunks are pulled in on each side. When you already
+    know the exact range and want those chunks verbatim, use read() instead.
 
     Args:
         source_id:    Source identifier from a search() result.
@@ -297,8 +301,10 @@ async def read(
     end_offset: int | None = None,
     top_k: int = 20,
 ) -> list[dict]:
-    """Read chunks from a known character-offset range within a source.
+    """Fetch chunks from a known offset range: direct access, no context expansion.
 
+    Use when you already know the source and the exact range you want, and just
+    want those chunks back as-is (unlike open(), which expands around a chunk).
     Pass None for start_offset to read from the beginning, or None for
     end_offset to read to the end of the document.
 

--- a/template/tests/test_mcp_tools.py
+++ b/template/tests/test_mcp_tools.py
@@ -1,0 +1,110 @@
+"""The MCP navigation tools keep the shape the agent loop depends on.
+
+The round-trip test covers storing and finding a document; this one covers the seam the
+MCP server owns on top of that: that `open` and `read` expose the *distinct* contracts the
+agentic search loop is built around, and that `open` actually resolves a chunk id to a
+position before it windows around it.
+
+- `open(chunk_id, window)`   -- "I have a chunk from search, show me context around it."
+  The caller passes only the opaque chunk `id`; the server resolves its position via
+  `NavigableIndex.get_chunk` and pulls in neighbours. If this silently reverts to taking
+  raw offsets, the tool becomes indistinguishable from `read` and the distinction the docs
+  teach stops being true.
+- `read(source_id, start_offset, end_offset)` -- "I know the exact range, give me those
+  chunks." Offset-addressed, no expansion.
+
+No backend and no API key are needed: `open`'s logic is exercised against a fake store, and
+the schema is read off the registered tools. `mcp_server` fails fast at import without
+`MISTRAL_API_KEY` and loads `.env` with `override=True`, so the fixture neutralises the
+dotenv load and sets a placeholder key -- it is never used to make a call.
+"""
+
+import asyncio
+import importlib
+
+import pytest
+
+from mistralai.search.toolkit.document import ChunkType
+from mistralai.search.toolkit.search import NavigationDirection
+from mistralai.search.toolkit.search.models import SearchResult, SearchResultChunk
+
+
+@pytest.fixture
+def mcp_server(monkeypatch: pytest.MonkeyPatch):
+    """Import `entrypoints.mcp_server` offline, with a placeholder key and dotenv disabled.
+
+    The module reads `.env` with `override=True` at import; the generated `.env` ships an
+    empty `MISTRAL_API_KEY`, which would clobber a value set here. Neutralising `load_dotenv`
+    before (re)import lets the placeholder stand so the import-time fail-fast passes.
+    """
+    import dotenv
+
+    monkeypatch.setattr(dotenv, "load_dotenv", lambda *args, **kwargs: False)
+    monkeypatch.setenv("MISTRAL_API_KEY", "test-key-not-used")
+
+    import entrypoints.mcp_server as module
+
+    return importlib.reload(module)
+
+
+def _result(chunk_id: str, start: int, end: int, content: str) -> SearchResult:
+    chunk = SearchResultChunk(
+        id=chunk_id,
+        source_id="doc-1",
+        locator=f"chunk_idx:{start}",
+        content=content,
+        start_offset=start,
+        end_offset=end,
+        chunk_type=ChunkType.CONTENT,
+    )
+    return SearchResult(score=0.0, chunk=chunk)
+
+
+class _FakeStore:
+    """Minimal `NavigableIndex` stand-in: knows one chunk and one neighbour in each direction."""
+
+    async def get_chunk(self, chunk_id: str, **_: object) -> SearchResult | None:
+        return _result("c2", 10, 20, "anchor") if chunk_id == "c2" else None
+
+    async def navigate(
+        self, source_id: str, start: int, end: int, direction: NavigationDirection, *, top_k: int = 1, **_: object
+    ) -> list[SearchResult]:
+        if direction == NavigationDirection.PREVIOUS:
+            return [_result("c1", 0, 10, "before")]
+        return [_result("c3", 20, 30, "after")]
+
+
+def _open_fn(mcp_server):
+    # `open` shadows the builtin; @mcp.tool() wraps it, so reach the coroutine through `.fn`.
+    return getattr(mcp_server.open, "fn", mcp_server.open)
+
+
+def test_open_takes_a_chunk_id_and_read_stays_offset_addressed(mcp_server) -> None:
+    open_tool = asyncio.run(mcp_server.mcp.get_tool("open"))
+    read_tool = asyncio.run(mcp_server.mcp.get_tool("read"))
+
+    assert set(open_tool.parameters["properties"]) == {"chunk_id", "window"}
+    assert open_tool.parameters.get("required") == ["chunk_id"]
+
+    read_props = read_tool.parameters["properties"]
+    assert "start_offset" in read_props and "end_offset" in read_props
+    assert "chunk_id" not in read_props
+
+
+def test_open_resolves_the_chunk_and_windows_around_it(mcp_server, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mcp_server, "_navigable_store", _FakeStore())
+
+    out = asyncio.run(_open_fn(mcp_server)("c2", window=1))
+
+    # Previous neighbour, the resolved anchor, then the next neighbour -- in reading order.
+    assert [r["id"] for r in out] == ["c1", "c2", "c3"]
+    assert [r["content"] for r in out] == ["before", "anchor", "after"]
+
+
+def test_open_raises_when_the_chunk_id_is_unknown(mcp_server, monkeypatch: pytest.MonkeyPatch) -> None:
+    from fastmcp.exceptions import ToolError
+
+    monkeypatch.setattr(mcp_server, "_navigable_store", _FakeStore())
+
+    with pytest.raises(ToolError):
+        asyncio.run(_open_fn(mcp_server)("does-not-exist"))


### PR DESCRIPTION
Follow-up from @haralambievk's starter-app review ([Slack](https://mistralai.slack.com/archives/C0BND2VNSBG/p1787296312074859?thread_ts=1786461905.129789&cid=C0BND2VNSBG)).

Aligns the `open` vs `read` MCP tools with the canonical semantics (per the `dashboard` reference impl at `search/substrate/mcp/src/server`):

- **`open(chunk_id, window)`** — expand context around a chunk from `search`. The caller passes the chunk `id`; the server resolves its position via `NavigableIndex.get_chunk` and returns the anchor plus `window` neighbours on each side (context expansion).
- **`read(source_id, start_offset, end_offset)`** — fetch a known offset range directly, no expansion (direct access).

### Changes in `template/`
- **`open` signature is now `open(chunk_id, window)`** (was the flat `open(source_id, start_offset, end_offset, window)`); it resolves position internally via `get_chunk`. This is the actual semantic distinction Kris raised in review — `open` = "I have a chunk, show me context around it"; `read` = "I know the exact range, give me those chunks."
- **`search` results now surface the chunk `id`** so the model has something to pass to `open`.
- `FastMCP` instructions + `open`/`read` docstrings updated for the semantics.
- README tool table updated (renamed tools, new signatures).
- New offline test `tests/test_mcp_tools.py` covering the `open`/`read` contracts and `open()`'s id resolution.

### Verification
- vespa + postgres integration suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)