### PR TITLE
feat(mcp): expose exclude_ids on the search tool

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -13,7 +13,7 @@ dependencies = [
     # number. The `vespa` extra pulls the plugin, whose own dependency on core carries no lower
     # bound -- so a core pin left behind a plugin release resolves to a pair that imports names
     # the older core does not have. Bump both by bumping this.
-    "mistralai-search-toolkit[text-splitter-langchain,vespa]==0.0.11",
+    "mistralai-search-toolkit[text-splitter-langchain,vespa]==0.0.13",
 {%- else %}
     # No version pin on the postgres branch: the plugin depends on unreleased
     # core APIs (e.g. ChunkPatch) that are absent from the published ==0.0.10

--- a/template/src/entrypoints/mcp_server.py
+++ b/template/src/entrypoints/mcp_server.py
@@ -123,18 +123,24 @@ def _format_chunks(results: list) -> list[dict]:
 
 
 @mcp.tool()
-async def search(query: str, top_k: int = 5) -> list[dict]:
+async def search(
+    query: str, top_k: int = 5, exclude_ids: list[str] | None = None
+) -> list[dict]:
     """Search the document collection and return the most relevant chunks.
 
     Args:
-        query: Natural-language search query.
-        top_k: Maximum number of results to return (default 5).
+        query:       Natural-language search query.
+        top_k:       Maximum number of results to return (default 5).
+        exclude_ids: Chunk `id`s to skip at query time — e.g. chunks already
+                     seen earlier in an agentic loop, so each search surfaces
+                     fresh context instead of repeating hits.
     """
     result = await _query_engine.search(
         query=query,
         top_k=top_k,
         include_metadata=True,
         include_content=True,
+        exclude_ids=set(exclude_ids) if exclude_ids else None,
     )
     return _format_chunks(result.results)
 

--- a/template/tests/test_mcp_tools.py
+++ b/template/tests/test_mcp_tools.py
@@ -79,6 +79,54 @@ def _open_fn(mcp_server):
     return getattr(mcp_server.open, "fn", mcp_server.open)
 
 
+def _search_fn(mcp_server):
+    return getattr(mcp_server.search, "fn", mcp_server.search)
+
+
+class _EngineResult:
+    def __init__(self, results: list[SearchResult]) -> None:
+        self.results = results
+
+
+class _RecordingEngine:
+    """Captures the kwargs `search` forwards, returns one canned hit."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def search(self, **kwargs: object) -> _EngineResult:
+        self.calls.append(kwargs)
+        return _EngineResult([_result("c1", 0, 10, "hit")])
+
+
+def test_search_exposes_exclude_ids(mcp_server) -> None:
+    search_tool = asyncio.run(mcp_server.mcp.get_tool("search"))
+    props = search_tool.parameters["properties"]
+
+    assert "exclude_ids" in props
+    # Only `query` is mandatory; exclude_ids stays optional.
+    assert search_tool.parameters.get("required") == ["query"]
+
+
+def test_search_forwards_exclude_ids_as_a_set(mcp_server, monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = _RecordingEngine()
+    monkeypatch.setattr(mcp_server, "_query_engine", engine)
+
+    asyncio.run(_search_fn(mcp_server)("q", exclude_ids=["a", "b", "a"]))
+
+    assert engine.calls[0]["exclude_ids"] == {"a", "b"}
+
+
+def test_search_defaults_exclude_ids_to_none(mcp_server, monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = _RecordingEngine()
+    monkeypatch.setattr(mcp_server, "_query_engine", engine)
+
+    asyncio.run(_search_fn(mcp_server)("q"))
+
+    # Empty/absent stays None so the backend skips the filter entirely.
+    assert engine.calls[0]["exclude_ids"] is None
+
+
 def test_open_takes_a_chunk_id_and_read_stays_offset_addressed(mcp_server) -> None:
     open_tool = asyncio.run(mcp_server.mcp.get_tool("open"))
     read_tool = asyncio.run(mcp_server.mcp.get_tool("read"))


### PR DESCRIPTION
## What

Bump the vespa pin to `mistralai-search-toolkit==0.0.13` and surface `exclude_ids` on the MCP `search` tool. This param was missing until now.

## Why

0.0.13 plumbs `exclude_ids` through `QueryEngine.search` (commit `b22cc6f`, "plumb exclude_ids through QueryEngine retrieval"). Exposing it lets an agentic loop skip chunks it has already seen, so each `search` surfaces fresh context instead of repeating hits.

## Changes

- **`template/pyproject.toml.jinja`** — vespa pin `0.0.11` → `0.0.13`. Postgres branch untouched: it resolves core from the local monorepo checkout, which already carries the param.
- **`template/src/entrypoints/mcp_server.py`** — `search` gains `exclude_ids: list[str] | None = None`, forwarded as a `set` (or `None` when empty, so the backend drops the filter entirely).
- **`template/tests/test_mcp_tools.py`** — 3 tests: param exposed in schema, `query` stays the only required arg, list dedups to a set, absent stays `None`.

## Verification

- 0.0.13 resolves with the template's `exclude-newer-package` override; published wheel confirmed to carry `exclude_ids`.
- All 6 mcp tests (3 new + 3 existing) pass on a fresh vespa render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)