### PR TITLE
Source postgres plugin from PyPI instead of local checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   integration-test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [vespa, postgres]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -19,4 +23,4 @@ jobs:
         run: uv tool install copier
 
       - name: Run integration tests
-        run: make integration-test
+        run: make integration-test BACKEND=${{ matrix.backend }}

--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,12 @@
 GENERATED_PROJECT := /tmp/search-starter-app-integration-test
 
 # Backend under test (vespa | postgres). Override on the command line, e.g.
-#   make integration-test BACKEND=postgres POSTGRES_PLUGIN_PATH=../dashboard/search/toolkit/plugins/postgres
+#   make integration-test BACKEND=postgres
 BACKEND ?= vespa
-
-# Local checkout of the (currently unpublished) postgres plugin. Required for
-# BACKEND=postgres so uv can resolve it via the generated [tool.uv.sources] shim.
-POSTGRES_PLUGIN_PATH ?=
 
 # Extra copier data passed to the postgres run.
 ifeq ($(BACKEND),postgres)
-COPIER_DATA := --data backend=postgres --data postgres_plugin_path=$(POSTGRES_PLUGIN_PATH)
+COPIER_DATA := --data backend=postgres
 else
 COPIER_DATA := --data backend=vespa
 endif
@@ -20,11 +16,9 @@ endif
 ## Generate a project from the template and run integration tests (default: vespa)
 integration-test: _integration-test-body
 
-## Generate + test the postgres variant. Requires POSTGRES_PLUGIN_PATH.
+## Generate + test the postgres variant.
 integration-test-postgres:
-	@test -n "$(POSTGRES_PLUGIN_PATH)" \
-		|| (echo "FAIL: set POSTGRES_PLUGIN_PATH to a local postgres plugin checkout" && exit 1)
-	$(MAKE) _integration-test-body BACKEND=postgres POSTGRES_PLUGIN_PATH=$(POSTGRES_PLUGIN_PATH)
+	$(MAKE) _integration-test-body BACKEND=postgres
 
 _integration-test-body:
 	@echo "=== integration-test (backend=$(BACKEND)) ==="

--- a/copier.yml
+++ b/copier.yml
@@ -56,14 +56,3 @@ collection_name:
     {% elif backend == 'postgres' and collection_name | length > 34 %}
     Too long for Postgres: at most 34 characters, because index names derive from it.
     {% endif %}
-
-postgres_plugin_path:
-  type: str
-  default: ""
-  when: "{{ backend == 'postgres' }}"
-  help: >-
-    Path to a local checkout of mistralai-search-toolkit-plugins-postgres
-    (e.g. ../dashboard/search/toolkit/plugins/postgres). The toolkit core is
-    resolved from its sibling (<path>/../../core), because the plugin needs
-    unreleased core APIs not in the published wheel. Required until the plugin
-    and a matching core are published; leave empty once they are on the index.

--- a/template/.agents/skills/search/SKILL.md.jinja
+++ b/template/.agents/skills/search/SKILL.md.jinja
@@ -273,6 +273,7 @@ CLI also supports `mistral-vespa bruno` and `mistral-vespa generate` (see `make 
 
 ```python
 from mistralai.search.toolkit.document import Document
+from mistralai.search.toolkit.embedding import MistralEmbeddingPreset, VectorDType
 from mistralai.search.toolkit.plugins.postgres import (
     PostgresApp,
     PostgresCollectionSchema,
@@ -284,8 +285,10 @@ app = PostgresApp(
         PostgresCollectionSchema(
             collection_name="exampledocs",
             document_type=Document,
-            dim=128,                     # match the embedder (MistralEmbedder → 128-dim)
-            distance_metric="cosine",
+            # Match the embedder (MistralEmbedder → 128-dim) and the migrated column (HALFVEC → float16).
+            embedding_model=MistralEmbeddingPreset.MISTRAL_EMBED_DIM_128.build_embedding_model(
+                dtype=VectorDType.FLOAT16,
+            ),
         )
     ]
 )
@@ -343,7 +346,7 @@ Subclasses: `VectorStoreIndex`, `KeywordStoreIndex`. Exceptions: `IndexingError`
 | Run this template end-to-end | `make setup-postgres` → `make ingest` → `make search` |
 | Apply schema changes | `make migrate` (or `make reset-postgres` to wipe first) |
 | Change the connection | `.env` `POSTGRES_DSN` + `docker-compose.yaml` |
-| Adjust the vector schema | `PostgresCollectionSchema` in `src/search_app/__init__.py` (dim, distance metric, HNSW params), then a new revision in `alembic/versions/` |
+| Adjust the vector schema | `PostgresCollectionSchema` in `src/search_app/__init__.py` (embedding model, distance metric, HNSW params), then a new revision in `alembic/versions/` |
 {%- endif %}
 | Index local files | `make ingest` or `Pipeline` + `FilesystemFileLoader` in `entrypoints/ingest.py` |
 | Index from S3/GCS/Azure | storage plugin loader + same `Pipeline` |

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -15,18 +15,14 @@ dependencies = [
     # the older core does not have. Bump both by bumping this.
     "mistralai-search-toolkit[text-splitter-langchain,vespa]==0.0.13",
 {%- else %}
-    # No version pin on the postgres branch: the plugin depends on unreleased
-    # core APIs (e.g. ChunkPatch) that are absent from the published ==0.0.10
-    # core wheel, so core is sourced from the local monorepo checkout via
-    # [tool.uv.sources] below. Pinning ==0.0.10 here would conflict with that
-    # local (post/dev-versioned) core and make the resolver unsatisfiable.
-    "mistralai-search-toolkit[text-splitter-langchain]",
-    # The postgres backend ships as a separate plugin wheel. Depend on it
-    # DIRECTLY rather than via a `[postgres]` extra: that extra is not on the
-    # published core package yet, and a `[tool.uv.sources]` override (below) only
-    # redirects a package that is already a declared dependency. Until the plugin
-    # is published this resolves from the local checkout in [tool.uv.sources].
-    "mistralai-search-toolkit-plugins-postgres",
+    # Pinned exactly, and core and the postgres plugin are released in lockstep on the same
+    # version number. The plugin's own dependency on core carries no lower bound, so a core
+    # pin left behind a plugin release resolves to a pair that imports names the older core
+    # does not have. Bump both by bumping these.
+    "mistralai-search-toolkit[text-splitter-langchain]==0.0.13",
+    # The postgres backend ships as a separate plugin wheel. Depend on it DIRECTLY rather
+    # than via a `[postgres]` extra, which is not on the published core package.
+    "mistralai-search-toolkit-plugins-postgres==0.0.13",
     # The collection's table is created by the Alembic chain in alembic/, not by a
     # create-if-absent call, so that one ordering governs the whole database once this
     # project grows tables of its own. `make migrate` runs it.
@@ -62,20 +58,7 @@ mistralai = false
 "mistral-common" = false
 "mistralai-search-toolkit" = false
 "mistralai-search-toolkit-plugins-{{ 'vespa' if backend == 'vespa' else 'postgres' }}" = false
-{% if backend == 'postgres' and postgres_plugin_path -%}
 
-# Neither the postgres plugin nor a matching core are published yet, and the
-# plugin depends on unreleased core APIs (e.g. ChunkPatch). So resolve BOTH the
-# plugin AND core from the local monorepo checkout. core lives next to the
-# plugin (search/toolkit/core alongside search/toolkit/plugins/postgres), so it
-# is derived as a sibling of postgres_plugin_path. The plugin's own pyproject
-# pins core via `workspace = true`; pointing the root at that same checkout keeps
-# the two in agreement. Remove this whole block once the plugin and a matching
-# core are published to the index.
-[tool.uv.sources]
-mistralai-search-toolkit = {{ '{' }} path = "{{ postgres_plugin_path }}/../../core", editable = true {{ '}' }}
-mistralai-search-toolkit-plugins-postgres = {{ '{' }} path = "{{ postgres_plugin_path }}", editable = true {{ '}' }}
-{% endif %}
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/template/src/search_app/__init__.py.jinja
+++ b/template/src/search_app/__init__.py.jinja
@@ -32,15 +32,21 @@ import os
 from sqlalchemy.engine import make_url
 
 from mistralai.search.toolkit.document import Document
+from mistralai.search.toolkit.embedding import MistralEmbeddingPreset, VectorDType
 from mistralai.search.toolkit.plugins.postgres import (
     PostgresApp,
     PostgresCollectionSchema,
     PostgresConnectionConfig,
 )
 
-# Embedding dimension must match the embedder used in the entrypoints.
-# MistralEmbedder defaults to the 128-dimension model.
-_EMBEDDING_DIM = 128
+# The embedding model must match the embedder used in the entrypoints (MistralEmbedder
+# defaults to mistral-embed-dim128-2510) and the column type the Alembic chain creates
+# (HALFVEC -> float16). A preset carries the dimensions and distance metric; building
+# it with FLOAT16 keeps the declared vector type in step with the migrated table, so
+# the store and the column agree at insert and query time.
+_EMBEDDING_MODEL = MistralEmbeddingPreset.MISTRAL_EMBED_DIM_128.build_embedding_model(
+    dtype=VectorDType.FLOAT16,
+)
 
 # Fixed at generation time rather than read from COLLECTION_NAME, because the Alembic
 # chain in alembic/versions/ builds a table of exactly this name. If the two could drift
@@ -55,8 +61,7 @@ COLLECTION_NAME = "{{ collection_name }}"
 POSTGRES_COLLECTION = PostgresCollectionSchema(
     collection_name=COLLECTION_NAME,
     document_type=Document,
-    dim=_EMBEDDING_DIM,
-    distance_metric="cosine",
+    embedding_model=_EMBEDDING_MODEL,
 )
 
 app = PostgresApp([POSTGRES_COLLECTION])

--- a/template/tests/test_search_roundtrip.py
+++ b/template/tests/test_search_roundtrip.py
@@ -29,9 +29,9 @@ from mistralai.search.toolkit.document import Document, DocumentChunk
 from mistralai.search.toolkit.search import VectorSearchQuery, VectorStoreIndex
 from search_app import get_index
 
-# Matches the dimension the app declares -- `_EMBEDDING_DIM` for Postgres, the schema's
-# `embedding_dimensions` for Vespa. Changing one without the other is what this test should fail
-# on, so it is stated here rather than imported from whichever backend is in use.
+# Matches the dimension the app declares -- 128 for Postgres (MistralEmbeddingPreset.MISTRAL_EMBED_DIM_128),
+# the schema's `embedding_dimensions` for Vespa. Changing one without the other is what this test
+# should fail on, so it is stated here rather than imported from whichever backend is in use.
 EMBEDDING_DIM = 128
 
 COLLECTION_NAME = os.environ.get("COLLECTION_NAME", "exampledocs")


### PR DESCRIPTION
## Summary
- The postgres plugin and a matching core are now published on PyPI at 0.0.13, so the local-monorepo-checkout shim is no longer needed.
- Drop the `postgres_plugin_path` Copier question and the generated `[tool.uv.sources]` override; pin both core and the plugin to `==0.0.13` (same lockstep pinning as the vespa backend).
- The `make integration-test-postgres` target no longer requires a local checkout, so wire the postgres backend into CI as a matrix alongside vespa.

## Test plan
- [ ] `make integration-test` (vespa) passes
- [ ] `make integration-test-postgres` passes — `uv lock` resolves both `mistralai-search-toolkit` and `mistralai-search-toolkit-plugins-postgres` from PyPI without a local path
- [ ] CI matrix runs both backends green

🤖 Generated with [Claude Code](https://claude.com/claude-code)